### PR TITLE
RSE-449: Fix: kill job win node not killing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ This add-on allows to track the PIDs of processes executed on a remote node, and
 
 2. Setup the `Capture Process IDs` log filter on your job. This filter will register any PID written to the execution output log according to the configured pattern.
 
+![image](https://github.com/rundeck-plugins/job-kill-handler-addon/assets/49494423/f303b5d2-4811-447a-8fa7-24a972623d81)
+
 For example, using the default configuration, you can print this string to the output log and the log filter will capture the value `2345`:
-```
-RUNDECK:PID:2345
-```
+![image](https://github.com/rundeck-plugins/job-kill-handler-addon/assets/49494423/51f128be-2588-41bb-b7a8-374ca3f5db66)
 
 3. Enable the `Kill tracked processes after execution` execution plugin. The default behavior is to kill any processes on the corresponding nodes with PIDs captured by the log filter after the job finishes for any reason, you can also make it kill children processes and/or only killing processes on job failure (job finishes with `FAIL` status or is killed).
+
+![image](https://github.com/rundeck-plugins/job-kill-handler-addon/assets/49494423/8d608c9d-ae27-49f2-b7c9-c0aa42258a4a)
 
 
 ## Operating System Support

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Rundeck Kill Handler Add-On
+This add-on allows to track the PIDs of processes executed on a remote node, and then issue a kill command for those PIDs when the job finish. The feature must be configured on each job where it's needed.
 
 ## Basic Usage
 
-This add-on allows to track the PIDs of processes executed on a remote node, and then issue a kill command for those PIDs when the job finish.
+1. To install the add-on copy the `rundeck-job-kill-handler-<version>.jar` file into the `$RDBASE/server/addons` directory.
 
-To enable, install the add-on and setup the `Capture Process IDs` log filter on your job. This filter will register any PID written to the execution output log according to the configured pattern.
+2. Setup the `Capture Process IDs` log filter on your job. This filter will register any PID written to the execution output log according to the configured pattern.
 
-For example, using the default configuration, you can print this string to the output log to register PID 2345 on the current node:
+For example, using the default configuration, you can print this string to the output log and the log filter will capture the value `2345`:
 ```
 RUNDECK:PID:2345
 ```
 
-Then to enable the killing of these processes at execution finish, enable the `Kill tracked processes after execution` execution plugin. This plugin will connect to each node after execution finish and issue a kill command for each of the tracked PIDs of that node. You can also configure the plugin to attempt to kill children processes of the registered PIDs.
+3. Enable the `Kill tracked processes after execution` execution plugin. The default behavior is to kill any processes on the corresponding nodes with PIDs captured by the log filter after the job finishes for any reason, you can also make it kill children processes and/or only killing processes on job failure (job finishes with `FAIL` status or is killed).
 
 
 ## Operating System Support
@@ -19,13 +20,12 @@ Then to enable the killing of these processes at execution finish, enable the `K
 Currently this plugin has been successfully tested on the following target node operating systems:
 - Ubuntu 18.04
 - Centos 6.10
+- Windows Server 2019
 
-The plugin should work correctly with any Linux node which complies with the following:
-- Node definition indicates `unix` osFamily
-- Target operating system supports posix process session ids (SID), specifically the `pkill -s` command.
+The plugin should work correctly with any Linux or Windows node which complies with the following:
+- Target operating system supports posix process session ids (SID), specifically the `pkill -s` command (only for killing children processess).
 
 Some BSD-like operating systems (like macOS) don't support process SID nor the `-s` flag for pkill, hence the "Kill Children" option will not work.
-Windows operating systems are not currently supported by this plugin.
 
 
 ## Building and Installing
@@ -36,7 +36,7 @@ To build the plugin, run the gradle build command:
 ```
 The resulting artifact will be found at `build/libs/job-kill-handler-VERSION.jar`
 
-For installing, copy the jar artifact to $RDBASE/server/addons directory. After restarting rundeck you should see the plugins available.
+For installing, copy the jar artifact to `$RDBASE/server/addons` directory. After restarting rundeck you should see the plugins available.
 
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This add-on allows to track the PIDs of processes executed on a remote node, and
 
 ## Basic Usage
 
-1. To install the add-on copy the `rundeck-job-kill-handler-<version>.jar` file into the `$RDBASE/server/addons` directory.
+1. To install the add-on copy the `rundeck-job-kill-handler-<version>.jar` file into the `$RDECK_BASE/server/addons` directory (`/var/lib/addons` in rpm).
 
 2. Setup the `Capture Process IDs` log filter on your job. This filter will register any PID written to the execution output log according to the configured pattern.
 
@@ -17,7 +17,9 @@ For example, using the default configuration, you can print this string to the o
 ![image](https://github.com/rundeck-plugins/job-kill-handler-addon/assets/49494423/8d608c9d-ae27-49f2-b7c9-c0aa42258a4a)
 
 
-## Operating System Support
+## Support
+
+Process Automation Version: 4.13 or higher.
 
 Currently this plugin has been successfully tested on the following target node operating systems:
 - Ubuntu 18.04

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ groovyVersion=2.5.6
 grailsVersion=4.0.3
 gormVersion=7.0.4.RELEASE
 assetPluginVersion=3.0.11
-rundeckVersion=3.2.6-20200427
+rundeckVersion=4.13.0-20230515

--- a/rundeck-job-kill-handler/src/main/groovy/com/rundeck/plugins/killhandler/KillHandlerExecutionLifecyclePlugin.groovy
+++ b/rundeck-job-kill-handler/src/main/groovy/com/rundeck/plugins/killhandler/KillHandlerExecutionLifecyclePlugin.groovy
@@ -80,7 +80,7 @@ This operation will only affect nodes with 'unix' as osFamily, and will use the 
                         event.executionLogger.log(Constants.DEBUG_LEVEL, "Result from killing processes attempt: "+ result)
 
                         // Kill children processes
-                        if (killChilds) {
+                        if (killChilds && !OSFAMILY_WINDOWS.equalsIgnoreCase(node.osFamily)) {
                             event.executionLogger.log(Constants.DEBUG_LEVEL, "Killing processes by parent on node '${node.nodename}': ${commaPidList}")
                             // When the parent pid is killed, children processes change its ppid to 1 (init pid)
                             // To circumvent this, we issue a kill by SID also.

--- a/rundeck-job-kill-handler/src/main/groovy/com/rundeck/plugins/killhandler/KillHandlerProcessTrackingService.groovy
+++ b/rundeck-job-kill-handler/src/main/groovy/com/rundeck/plugins/killhandler/KillHandlerProcessTrackingService.groovy
@@ -37,7 +37,8 @@ class KillHandlerProcessTrackingService {
      * @return
      */
     Map<String, NodePidList> getExecutionTrackData(String executionId) {
-        return Collections.unmodifiableMap(executionTrackMap.get(executionId))
+        ConcurrentHashMap<String, NodePidList> execPIDsMap = executionTrackMap.get(executionId)
+        return execPIDsMap ? Collections.unmodifiableMap(execPIDsMap) : null
     }
 
     /**


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-449

#### Problem
When running a script step that has an infinite script against a windows node using pywinrm, the script will keep running even if the job is killed.
* Script step example:
```
$LogFile = "C:\Windows\temp\testkilljob.log"
"" | Out-File $LogFile
while(1) {
sleep 1
$a = Get-Random
Write-Host $a
$a | Out-File $LogFile -Append
}
```

#### Solution
Make `job-kill-handler-addon` work against windows, update code to work using 4.13.x rundeck core and update documentation.